### PR TITLE
A small PR that makes it possible for pipes to fill soul containers.

### DIFF
--- a/src/main/java/com/buuz135/industrialforegoingsouls/block/tile/SoulPipeBlockEntity.java
+++ b/src/main/java/com/buuz135/industrialforegoingsouls/block/tile/SoulPipeBlockEntity.java
@@ -29,8 +29,13 @@ public class SoulPipeBlockEntity extends NetworkBlockEntity<SoulPipeBlockEntity>
             if (capability != null) {
                 var network = getNetwork();
                 if (network != null) {
-                    var simulated = capability.drain(4, ISoulHandler.Action.SIMULATE);
-                    capability.drain(network.addSouls(this.level, simulated), ISoulHandler.Action.EXECUTE);
+                    var simulatedFill = capability.fill(4, ISoulHandler.Action.SIMULATE);
+                    var filled = capability.fill(network.drainSouls(this.level, simulatedFill), ISoulHandler.Action.EXECUTE);
+                    // don't try to fill and drain on the same tick
+                    if (filled == 0) {
+                        var simulatedDrain = capability.drain(4, ISoulHandler.Action.SIMULATE);
+                        capability.drain(network.addSouls(this.level, simulatedDrain), ISoulHandler.Action.EXECUTE);                            
+                    }
                 }
             }
         }

--- a/src/main/java/com/buuz135/industrialforegoingsouls/block_network/SoulNetwork.java
+++ b/src/main/java/com/buuz135/industrialforegoingsouls/block_network/SoulNetwork.java
@@ -48,6 +48,13 @@ public class SoulNetwork extends Network {
         return this.soulAmount - oldAmount;
     }
 
+    public int drainSouls(Level level, int soulAmount){
+        var oldAmount = this.soulAmount;
+        this.soulAmount = Math.max(0, oldAmount - soulAmount);
+        if (level != null) NetworkManager.get(level).setDirty(true);
+        return oldAmount - this.soulAmount;
+    }
+
     public boolean useSoul(Level level){
         if (this.soulAmount > 0) {
             --this.soulAmount;


### PR DESCRIPTION
Pipes can now push souls into ISoulHandler capability handlers.

You still wouldn't want to have a storage that can push and pull from the same block face (it'll work, but it'll keep pushing and pulling souls every tick), but you can at least do something like register the bottom as an output and the top as an input.

Here's an example of it I have working where one Catalyst block is harvesting souls and then feeding them to an array of Catalyst blocks. The Catalyst is set up to fill from the top/sides and drain from the bottom.

![2025-04-16_10 42 30](https://github.com/user-attachments/assets/f47f88d9-4e61-4ace-a3ba-8b053aab5d44)